### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cli = ["dirs", "jose", "structopt", "toml", "atty", "serde_json", "config"]
 
 [dependencies]
 atty = { version = "0.2", optional = true }
-chrono = { version = "0", features = ["serde"], optional = true }
+chrono = { version = "0.4", features = ["serde"], optional = true }
 config = { version = "0.13", optional = true }
 diesel = { version = "1", features = ["postgres"], optional = true }
 dirs = { version = "4", optional = true }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.